### PR TITLE
Open Curate dashboard from extension icon

### DIFF
--- a/background.js
+++ b/background.js
@@ -145,3 +145,13 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         return true;
     }
 });
+
+chrome.action.onClicked.addListener((tab) => {
+    const dashboardUrl = chrome.runtime.getURL('newtab.html');
+
+    if (tab && tab.url === dashboardUrl) {
+        return;
+    }
+
+    chrome.tabs.create({ url: dashboardUrl });
+});

--- a/manifest.json
+++ b/manifest.json
@@ -3,9 +3,6 @@
   "description": "Clock, decimal age, and a Discogs watchlist for new releases.",
   "version": "7.1.0",
   "manifest_version": 3,
-  "chrome_url_overrides": {
-    "newtab": "newtab.html"
-  },
   "options_page": "options.html",
   "action": {
     "default_title": "Curate Watchlist"

--- a/popup.js
+++ b/popup.js
@@ -35,7 +35,7 @@ async function addSlug(slug){
   if (!slugs.includes(slug)){
     slugs.push(slug); slugs.sort((a,b)=>a.localeCompare(b));
     await setSlugs(slugs);
-    setStatus(`Added “${slug}” from /releases page. Open a new tab and press Refresh.`);
+    setStatus(`Added “${slug}” from /releases page. Open the dashboard from the extension icon and press Refresh.`);
   }else{
     setStatus(`“${slug}” is already in your watchlist.`);
   }


### PR DESCRIPTION
## Summary
- remove the new tab override and launch the dashboard via the extension action instead
- guard against opening duplicate dashboard tabs and refresh messaging in the Beatport popup

## Testing
- not run (extension change)


------
https://chatgpt.com/codex/tasks/task_e_68dd06c6f0d88330a175b9038b3538cd